### PR TITLE
Add DCO sign-off instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Or let pre-commit hooks handle it automatically.
 We use `flake8` for linting. Run it with:
 
 ```bash
-uv run flake8 src/ 
+uv run flake8 src/
 ```
 
 ### Documentation
@@ -274,24 +274,59 @@ When suggesting features:
 - **Discussions**: Use GitHub Discussions for general questions
 - **Documentation**: Check the README and module-specific docs
 
-## Signing Your Work
+#### Signing Your Work
 
-We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
+* We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
 
-Any contribution which contains commits that are not Signed-Off will not be accepted.
+  * Any contribution which contains commits that are not Signed-Off will not be accepted.
 
-To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
+* To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
+  ```bash
+  $ git commit -s -m "Add cool feature."
+  ```
+  This will append the following to your commit message:
+  ```
+  Signed-off-by: Your Name <your@email.com>
+  ```
 
-```bash
-$ git commit -s -m "Add cool feature."
-```
+* Full text of the DCO (https://developercertificate.org/):
 
-This will append the following to your commit message:
+  ```
+    Developer Certificate of Origin
+    Version 1.1
 
-```
-Signed-off-by: Your Name <your@email.com>
-```
+    Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
 
+    Everyone is permitted to copy and distribute verbatim copies of this
+    license document, but changing it is not allowed.
+
+
+    Developer's Certificate of Origin 1.1
+
+    By making a contribution to this project, I certify that:
+
+    (a) The contribution was created in whole or in part by me and I
+        have the right to submit it under the open source license
+        indicated in the file; or
+
+    (b) The contribution is based upon previous work that, to the best
+        of my knowledge, is covered under an appropriate open source
+        license and I have the right under that license to submit that
+        work with modifications, whether created in whole or in part
+        by me, under the same open source license (unless I am
+        permitted to submit under a different license), as indicated
+        in the file; or
+
+    (c) The contribution was provided directly to me by some other
+        person who certified (a), (b) or (c) and I have not modified
+        it.
+
+    (d) I understand and agree that this project and the contribution
+        are public and that a record of the contribution (including all
+        personal information I submit with it, including my sign-off) is
+        maintained indefinitely and may be redistributed consistent with
+        this project or the open source license(s) involved.
+  ```
 ## Developer Certificate of Origin
 ```
 Developer Certificate of Origin


### PR DESCRIPTION
## Summary
- add a Signing Your Work section to CONTRIBUTING.md
- include commit sign-off instructions and the Developer Certificate of Origin text
- remove trailing whitespace in CONTRIBUTING.md while editing