### PR TITLE
Add third-party license inventory

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,263 @@
+# Third-Party Licenses
+
+This file lists third-party libraries and imported modules identified in this repository, along with their license information and source references.
+
+Copyright anndata contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to anndata.
+License Text(https://pypi.org/pypi/anndata/json)
+
+Copyright argparse contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to argparse.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright bertopic contributors - MIT License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to bertopic.
+License Text(https://pypi.org/pypi/bertopic/json)
+
+Copyright bokeh contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to bokeh.
+License Text(https://pypi.org/pypi/bokeh/json)
+
+Copyright collections contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to collections.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright cupy contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to cupy.
+License Text(https://pypi.org/pypi/cupy/json)
+
+Copyright cupyx contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to cupyx.
+License Text(https://pypi.org/project/cupy/)
+
+Copyright dash contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to dash.
+License Text(https://pypi.org/pypi/dash/json)
+
+Copyright dash_core_components contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to dash_core_components.
+License Text(https://pypi.org/pypi/dash-core-components/json)
+
+Copyright dash_html_components contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to dash_html_components.
+License Text(https://pypi.org/pypi/dash-html-components/json)
+
+Copyright dask contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to dask.
+License Text(https://pypi.org/pypi/dask/json)
+
+Copyright dask_cuda contributors - Apache-2.0
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to dask_cuda.
+License Text(https://github.com/rapidsai/dask-cuda/blob/main/LICENSE)
+
+Copyright datashader contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to datashader.
+License Text(https://pypi.org/pypi/datashader/json)
+
+Copyright datetime contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to datetime.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright fastai contributors - Apache-2.0
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to fastai.
+License Text(https://pypi.org/pypi/fastai/json)
+
+Copyright functools contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to functools.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright gc contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to gc.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright geopy contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to geopy.
+License Text(https://pypi.org/pypi/geopy/json)
+
+Copyright glob contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to glob.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright gmaps contributors - BSD License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to gmaps.
+License Text(https://github.com/pbugnion/gmaps/blob/master/LICENSE.txt)
+
+Copyright gzip contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to gzip.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright hdbscan contributors - OSI Approved (license field: BSD)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to hdbscan.
+License Text(https://pypi.org/pypi/hdbscan/json)
+
+Copyright hvplot contributors - BSD
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to hvplot.
+License Text(https://pypi.org/pypi/hvplot/json)
+
+Copyright io contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to io.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright IPython contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to IPython.
+License Text(https://pypi.org/pypi/ipython/json)
+
+Copyright ipywidgets contributors - BSD License (license field: BSD 3-Clause License)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to ipywidgets.
+License Text(https://pypi.org/pypi/ipywidgets/json)
+
+Copyright itertools contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to itertools.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright jupyter_dash contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to jupyter_dash.
+License Text(https://pypi.org/pypi/jupyter-dash/json)
+
+Copyright math contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to math.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright matplotlib contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to matplotlib.
+License Text(https://pypi.org/pypi/matplotlib/json)
+
+Copyright mlxtend contributors - BSD License (license field: BSD 3-Clause)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to mlxtend.
+License Text(https://pypi.org/pypi/mlxtend/json)
+
+Copyright networkx contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to networkx.
+License Text(https://pypi.org/pypi/networkx/json)
+
+Copyright numba contributors - BSD
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to numba.
+License Text(https://pypi.org/pypi/numba/json)
+
+Copyright numpy contributors - BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to numpy.
+License Text(https://pypi.org/pypi/numpy/json)
+
+Copyright os contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to os.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright pandas contributors - BSD License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pandas.
+License Text(https://pypi.org/pypi/pandas/json)
+
+Copyright pathlib contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pathlib.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright pickle contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pickle.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright plotly contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to plotly.
+License Text(https://pypi.org/pypi/plotly/json)
+
+Copyright pynvml contributors - BSD
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pynvml.
+License Text(https://pypi.org/pypi/nvidia-ml-py/json)
+
+Copyright pyproj contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pyproj.
+License Text(https://pypi.org/pypi/pyproj/json)
+
+Copyright queue contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to queue.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright requests contributors - Apache Software License (license field: Apache-2.0)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to requests.
+License Text(https://pypi.org/pypi/requests/json)
+
+Copyright scanpy contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to scanpy.
+License Text(https://pypi.org/pypi/scanpy/json)
+
+Copyright scipy contributors - BSD License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to scipy.
+License Text(https://pypi.org/pypi/scipy/json)
+
+Copyright seaborn contributors - BSD License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to seaborn.
+License Text(https://pypi.org/pypi/seaborn/json)
+
+Copyright sentence_transformers contributors - Apache-2.0
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to sentence_transformers.
+License Text(https://pypi.org/pypi/sentence-transformers/json)
+
+Copyright seqeval contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to seqeval.
+License Text(https://pypi.org/pypi/seqeval/json)
+
+Copyright shutil contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to shutil.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright sklearn contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to sklearn.
+License Text(https://pypi.org/pypi/scikit-learn/json)
+
+Copyright subprocess contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to subprocess.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright sys contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to sys.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright tarfile contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to tarfile.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright tensorflow contributors - Apache Software License (license field: Apache 2.0)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to tensorflow.
+License Text(https://pypi.org/pypi/tensorflow/json)
+
+Copyright termcolor contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to termcolor.
+License Text(https://pypi.org/pypi/termcolor/json)
+
+Copyright threading contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to threading.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright time contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to time.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright torch contributors - BSD-3-Clause
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to torch.
+License Text(https://pypi.org/pypi/torch/json)
+
+Copyright tqdm contributors - MPL-2.0 AND MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to tqdm.
+License Text(https://pypi.org/pypi/tqdm/json)
+
+Copyright transformers contributors - Apache 2.0 License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to transformers.
+License Text(https://pypi.org/pypi/transformers/json)
+
+Copyright umap contributors - OSI Approved (license field: BSD)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to umap.
+License Text(https://pypi.org/pypi/umap-learn/json)
+
+Copyright urllib contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to urllib.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright warnings contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to warnings.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright wget contributors - Public Domain
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to wget.
+License Text(https://pypi.org/pypi/wget/json)
+
+Copyright xgboost contributors - Apache Software License (license field: Apache-2.0)
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to xgboost.
+License Text(https://pypi.org/pypi/xgboost/json)


### PR DESCRIPTION
## Summary
- add THIRD_PARTY_LICENSES.md
- list imported libraries/modules, licenses, and source URLs from the provided inventory table

## Notes
- generated from the provided repo/top_level_import/license/source_url table