### PR TITLE
Add SPDX headers to shell and C++ files

### DIFF
--- a/GTC_2021/credit_scorecard/cpu/__init__.py
+++ b/GTC_2021/credit_scorecard/cpu/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/GTC_2021/credit_scorecard/cpu/data_utils.py
+++ b/GTC_2021/credit_scorecard/cpu/data_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from woesc_utils import *

--- a/GTC_2021/credit_scorecard/cpu/woesc_utils.py
+++ b/GTC_2021/credit_scorecard/cpu/woesc_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/GTC_2021/credit_scorecard/gpu/__init__.py
+++ b/GTC_2021/credit_scorecard/gpu/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/GTC_2021/credit_scorecard/gpu/woesc_utils_gpu.py
+++ b/GTC_2021/credit_scorecard/gpu/woesc_utils_gpu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/GTC_Spring_2022/numerical-computing/examples/src/_kernels.py
+++ b/GTC_Spring_2022/numerical-computing/examples/src/_kernels.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/GTC_Spring_2022/numerical-computing/examples/src/simulator.py
+++ b/GTC_Spring_2022/numerical-computing/examples/src/simulator.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/GTC_Spring_2022/numerical-computing/examples/src/solvers.py
+++ b/GTC_Spring_2022/numerical-computing/examples/src/solvers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/GTC_Spring_2022/numerical-computing/examples/src/utils.py
+++ b/GTC_Spring_2022/numerical-computing/examples/src/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/GTC_Spring_2022/numerical-computing/examples/src/visualize.py
+++ b/GTC_Spring_2022/numerical-computing/examples/src/visualize.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/KDD_2019/plasticc/cudf_agg.py
+++ b/KDD_2019/plasticc/cudf_agg.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import cudf as gd

--- a/KDD_2019/plasticc/rnn.py
+++ b/KDD_2019/plasticc/rnn.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd

--- a/KDD_2019/plasticc/utils.py
+++ b/KDD_2019/plasticc/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd

--- a/KDD_2020/kdd_initial_setup.sh
+++ b/KDD_2020/kdd_initial_setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script sets up the RAPIDS nightly container for the KDD 2020 hands-on tutorial
 
 echo "****************************************************************"

--- a/KDD_2020/notebooks/Lungs/rapids_scanpy_funcs.py
+++ b/KDD_2020/notebooks/Lungs/rapids_scanpy_funcs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 #

--- a/KDD_2020/notebooks/Taxi/nyctaxi_data.py
+++ b/KDD_2020/notebooks/Taxi/nyctaxi_data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/KDD_2020/notebooks/parking/__patch/cuspatial_init_patched.py
+++ b/KDD_2020/notebooks/parking/__patch/cuspatial_init_patched.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from .core.gis import (

--- a/TMLS_2020/notebooks/Taxi/nyctaxi_data.py
+++ b/TMLS_2020/notebooks/Taxi/nyctaxi_data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to shell scripts and C++ files
- preserve shell shebang placement where present
- replace `<year>` with `2026` in existing Python SPDX copyright headers

## Notes
- C++ files use block-comment SPDX headers.
- Shell scripts use `#` SPDX headers so scripts remain valid.